### PR TITLE
Update runtime to 5.15-23.08

### DIFF
--- a/net.meijn.onvifviewer.yaml
+++ b/net.meijn.onvifviewer.yaml
@@ -21,7 +21,7 @@ modules:
     url: https://github.com/KDAB/KDSoap.git
     tag: kdsoap-1.10.0
     commit: ea2d532bcef8a84991b137b0bfc1716d28b2eb67
-    
+
 - name: kdsoap-ws-discovery-client
   buildsystem: cmake-ninja
   config-opts:
@@ -30,7 +30,7 @@ modules:
   - type: git
     url: https://gitlab.com/caspermeijn/kdsoap-ws-discovery-client.git
     commit: dcefb65c88e76f1f9eda8b0318006e93d15a0e1e
-    
+
 - name: onvifviewer
   buildsystem: cmake-ninja
   config-opts:
@@ -40,12 +40,12 @@ modules:
     url: https://gitlab.com/caspermeijn/onvifviewer.git
     tag: v0.13
     commit: 78bb74ae44e9823b47b05e2f2bcde591b748e9dc
-    
+
 cleanup:
 - "/bin/kdwsdl2cpp"
 - "/include"
-- "/lib/pkgconfig"
 - "/lib/cmake"
-- "/share/mkspecs"
 - "/lib/libkdsoap-server.so*"
+- "/lib/pkgconfig"
 - "/share/doc"
+- "/share/mkspecs"

--- a/net.meijn.onvifviewer.yaml
+++ b/net.meijn.onvifviewer.yaml
@@ -5,11 +5,11 @@ runtime-version: '5.15-23.08'
 sdk: org.kde.Sdk
 command: onvifviewer
 finish-args:
-- "--socket=x11"
-- "--socket=wayland"
 - "--device=dri"
 - "--share=ipc"
 - "--share=network"
+- "--socket=fallback-x11"
+- "--socket=wayland"
 modules:
 
 - name: kdsoap

--- a/net.meijn.onvifviewer.yaml
+++ b/net.meijn.onvifviewer.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: net.meijn.onvifviewer
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-23.08'
 sdk: org.kde.Sdk
 command: onvifviewer
 finish-args:


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.